### PR TITLE
Deploy Performance Tuning Guide

### DIFF
--- a/guides/source/deploy_performance_tuning.md
+++ b/guides/source/deploy_performance_tuning.md
@@ -1,0 +1,92 @@
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
+
+Tuning Performance for Deployment
+=================================
+
+This guide covers performance and concurrency configuration for deploying your production Ruby on Rails application.
+
+After reading this guide, you will know:
+
+* Whether to use Puma, the default application server
+* How to configure important performance settings for Puma
+
+More information about how to configure your application can be found in the [Configuration Guide](configuring.html).
+
+--------------------------------------------------------------------------------
+
+Choosing an Application Server
+------------------------------
+
+An application server uses a particular concurrency method. For example Unicorn uses processes, Puma is hybrid process- and thread-based concurrency, Thin uses EventMachine and Falcon uses Ruby Fibers.
+
+A full discussion of Ruby's concurrency methods is beyond the scope of this document. If you want to use a method other than processes or threads, you will need to use a different application server. There are other features are only available with another server, such as Pitchfork's preforking.
+
+The most common application servers are used by removing the Puma gem from your Gemfile and including the gem for the server. Consult the appropriate application server documentation for details.
+
+Ruby Concurrency
+----------------
+
+Ruby has many kinds of concurrency. Puma supports a hybrid process-based and thread-based concurrency model.
+
+This guide is for [CRuby](https://ruby-lang.org), the original implementation of Ruby. If you're using a Ruby without a GVL such as JRuby or TruffleRuby, the configuration will be very different. If needed, check other sources specific to your Ruby implementation.
+
+### Process-Based Concurrency
+
+Puma calls its multi-process concurrency "clustered mode". In this mode it forks new worker processes from a master process and each one separately processes requests. Each worker is a fully-capable Ruby process, doing everything Ruby normally does.
+
+Creating new processes uses a lot of memory. Each worker contains all data from the master process. Ruby uses [copy-on-write memory](https://en.wikipedia.org/wiki/Copy-on-write) to avoid duplicating most master-process data that doesn't change. But process-based workers often use a lot of memory, especially long-running workers.
+
+Processes are resilient. Killing a single process doesn't affect other processes much. They are also slower to start up than threads. Loading your application in the master thread instead of the workers is called preloading. It helps startup time, but may increase memory use.
+
+### Thread-Based Concurrency
+
+Multiple threads can run in the same process. This avoids copying master data to each worker. Thread-based workers usually use much less memory than process-based workers.
+
+[CRuby](https://www.ruby-lang.org/en/) has a [Global Interpreter Lock](https://en.wikipedia.org/wiki/Global_interpreter_lock), often called the GVL or GIL. The GVL prevents multiple threads from running Ruby code at the same time in a single process. A thread can be waiting on network data, database operations or some other non-Ruby work, but only one can actively run Ruby code at a time. This means thread-based concurrency is more efficient for applications that use a lot of I/O such as database operations or network APIs. The more I/O your application uses, the more threads it would benefit from.
+
+With the GVL, using a lot of threads has limited value. A Rails app rarely benefits from more than 6. To have a large number of workers, some other concurrency method must be used.
+
+Threads are less resilient than processes. Certain errors like segmentation faults can destroy the entire process and all threads inside.
+
+Thread-based workers have much faster startup time than process-based workers. This isn't an issue for most long-running Rails servers, but can be important in some cases.
+
+### Hybrid Concurrency
+
+Puma allows forking multiple processes, each of which uses multiple threads. This provides a compromise between process-based and thread-based concurrency. Using multiple threads per process helps memory usage. But multiple processes are required for CRuby to run more Ruby code at the same time.
+
+Hybrid concurrency limits the damage from a segmentation fault or other error that kills a process. A single process dying will kill that process's threads but not threads in other processes.
+
+Choosing Default Settings
+-------------------------
+
+Rails' default settings are chosen for small applications. You can improve performance for your large application that serves a lot of requests by changing them.
+
+This section contains common sense defaults based on the type and size of your application and the hosts on which it runs. You can improve performance more by testing your application specifically. See "Performance Testing" for details.
+
+If you're using a Ruby implementation without a GVL such as JRuby or TruffleRuby the number of threads and processes will be completely different. These recommendations are only accurate for CRuby. These are also production recommendations. Your development application will have different needs from a production application, and should use a different configuration.
+
+### Threads Per Process
+
+Rails uses 3 threads per process by default. A well-optimized I/O-heavy Rails application should specify 5 or 6 threads per process at maximum. Discourse, for example, benefits from about 5 threads per process. Small applications with less I/O benefit from around 3 threads per process.
+
+From the default Puma configuration:
+
+    As a rule of thumb, increasing the number of threads will increase how much
+    traffic a given process can handle (throughput), but due to CRuby's
+    Global VM Lock (GVL) it has diminishing returns and will degrade the
+    response time (latency) of the application.
+
+### Number of Processes
+
+[Puma's deployment documentation](https://github.com/puma/puma/blob/master/docs/deployment.md) recommends running at least 1.5 processes per available processor core. Automatic methods to determine the number of cores are unreliable. You should specify the number of processes manually.
+
+### Preloading
+
+
+
+Performance Testing
+-------------------
+
+Settings from "Choosing Default Settings" are much better than using the initial Rails defaults. But your specific application may have unusual needs or benefit from different configuration options.
+
+The best way to choose your application's settings is to test the performance of your application with a simulated production workload.

--- a/guides/source/deploy_performance_tuning.md
+++ b/guides/source/deploy_performance_tuning.md
@@ -70,12 +70,7 @@ These are production recommendations. Your development application will have dif
 
 Rails uses 3 threads per process by default. A well-optimized I/O-heavy Rails application should specify 5 or 6 threads per process at maximum. Discourse, for example, benefits from about 5 threads per process. Discourse also executes many database queries per request and frequently uses Redis. More self-contained applications with fewer database and API queries benefit from around 3 threads per process.
 
-From the default Puma configuration:
-
-> As a rule of thumb, increasing the number of threads will increase how much
-> traffic a given process can handle (throughput), but due to CRuby's
-> Global VM Lock (GVL) it has diminishing returns and will degrade the
-> response time (latency) of the application.
+The default Puma configuration mentions that "as a rule of thumb, increasing the number of threads will increase how much traffic a given process can handle (throughput), but due to CRuby's Global VM Lock (GVL) it has diminishing returns and will degrade the response time (latency) of the application."
 
 To set the number of threads, you can change the call to the +threads+ method in +config/puma.rb+. Or you can set the +RAILS_MAX_THREADS+ environment variable, which will do the same.
 

--- a/guides/source/deploy_performance_tuning.md
+++ b/guides/source/deploy_performance_tuning.md
@@ -9,6 +9,7 @@ After reading this guide, you will know:
 
 * Whether to use Puma, the default application server
 * How to configure important performance settings for Puma
+* How to begin performance testing your application settings
 
 More information about how to configure your application can be found in the [Configuration Guide](configuring.html).
 
@@ -17,76 +18,146 @@ More information about how to configure your application can be found in the [Co
 Choosing an Application Server
 ------------------------------
 
-An application server uses a particular concurrency method. For example Unicorn uses processes, Puma is hybrid process- and thread-based concurrency, Thin uses EventMachine and Falcon uses Ruby Fibers.
+An application server uses a particular concurrency method. For example Unicorn uses processes, Puma and Passenger are hybrid process- and thread-based concurrency, Thin uses EventMachine and Falcon uses Ruby Fibers.
 
-A full discussion of Ruby's concurrency methods is beyond the scope of this document. If you want to use a method other than processes or threads, you will need to use a different application server. There are other features are only available with another server, such as Pitchfork's preforking.
+A full discussion of Ruby's concurrency methods is beyond the scope of this document. If you want to use a method other than processes or threads, you will need to use a different application server. Some features are only available with a specific server, such as Pitchfork's reforking.
 
-The most common application servers are used by removing the Puma gem from your Gemfile and including the gem for the server. Consult the appropriate application server documentation for details.
+Most common application servers are used by removing the Puma gem from your Gemfile and including the gem for that server. Consult the appropriate application server documentation for details.
 
 Ruby Concurrency
 ----------------
 
-Ruby has many kinds of concurrency. Puma supports a hybrid process-based and thread-based concurrency model.
+Ruby has many kinds of concurrency. Puma supports a hybrid process- and thread-based concurrency model.
 
-This guide is for [CRuby](https://ruby-lang.org), the original implementation of Ruby. If you're using a Ruby without a GVL such as JRuby or TruffleRuby, the configuration will be very different. If needed, check other sources specific to your Ruby implementation.
+This guide assumes you are running [CRuby](https://ruby-lang.org), the canonical implementation of Ruby. If you're using a Ruby implementation without a GVL nor forking support such as JRuby or TruffleRuby, most of this guide doesn't apply. If needed, check sources specific to your Ruby implementation.
 
 ### Process-Based Concurrency
 
-Puma calls its multi-process concurrency "clustered mode". In this mode it forks new worker processes from a master process and each one separately processes requests. Each worker is a fully-capable Ruby process, doing everything Ruby normally does.
+Puma calls its multi-process concurrency "clustered mode". In this mode it forks new worker processes from a master process and each one separately processes requests. Each worker is a fully-capable Ruby process.
 
-Creating new processes uses a lot of memory. Each worker contains all data from the master process. Ruby uses [copy-on-write memory](https://en.wikipedia.org/wiki/Copy-on-write) to avoid duplicating most master-process data that doesn't change. But process-based workers often use a lot of memory, especially long-running workers.
+Each forked worker significantly increase memory usage since each worker contains all data from the parent process. But Ruby leverages [copy-on-write memory](https://en.wikipedia.org/wiki/Copy-on-write) to avoid duplicating most master-process data that doesn't change. But process-based workers often use a lot of memory, especially long-running workers.
 
-Processes are resilient. Killing a single process doesn't affect other processes much. They are also slower to start up than threads. Loading your application in the master thread instead of the workers is called preloading. It helps startup time, but may increase memory use.
+Processes are resilient. Killing or crashing a single process doesn't affect other processes at all. Loading your application in the master process instead of the workers is called preloading. It can reduce memory usage by increasing the amount of memory that can be shared with the parent via copy-on-write.
 
 ### Thread-Based Concurrency
 
-Multiple threads can run in the same process. This avoids copying master data to each worker. Thread-based workers usually use much less memory than process-based workers.
+Multiple threads can run in the same process. This avoids multiple copies of shared data. Thread-based workers usually use much less memory than the same number of process-based workers.
 
-[CRuby](https://www.ruby-lang.org/en/) has a [Global Interpreter Lock](https://en.wikipedia.org/wiki/Global_interpreter_lock), often called the GVL or GIL. The GVL prevents multiple threads from running Ruby code at the same time in a single process. A thread can be waiting on network data, database operations or some other non-Ruby work, but only one can actively run Ruby code at a time. This means thread-based concurrency is more efficient for applications that use a lot of I/O such as database operations or network APIs. The more I/O your application uses, the more threads it would benefit from.
+[CRuby](https://www.ruby-lang.org/en/) has a [Global Interpreter Lock](https://en.wikipedia.org/wiki/Global_interpreter_lock), often called the GVL or GIL. The GVL prevents multiple threads from running Ruby code at the same time in a single process. Multiple threads can be waiting on network data, database operations or some other non-Ruby work, but only one can actively run Ruby code at a time. This means thread-based concurrency is more efficient for applications that use a lot of I/O such as database operations or network APIs. The more I/O your application uses, the more threads it would benefit from.
 
-With the GVL, using a lot of threads has limited value. A Rails app rarely benefits from more than 6. To have a large number of workers, some other concurrency method must be used.
+With the GVL, using a lot of threads has diminishing returns. A Rails app rarely benefits from more than 6. To have a large number of workers, some other concurrency method should be used.
 
-Threads are less resilient than processes. Certain errors like segmentation faults can destroy the entire process and all threads inside.
-
-Thread-based workers have much faster startup time than process-based workers. This isn't an issue for most long-running Rails servers, but can be important in some cases.
+Threads are less resilient than processes. Certain errors like segmentation faults can destroy the entire process and all threads inside. A single request allocating a lot of memory can stop all threads while the garbage collector runs.
 
 ### Hybrid Concurrency
 
-Puma allows forking multiple processes, each of which uses multiple threads. This provides a compromise between process-based and thread-based concurrency. Using multiple threads per process helps memory usage. But multiple processes are required for CRuby to run more Ruby code at the same time.
+Puma allows forking multiple processes, each of which uses multiple threads. This provides a compromise between process-based and thread-based concurrency. Using multiple threads per process helps memory usage. Multiple processes permit running more Ruby code at the same time since there is one GVL per process.
 
-Hybrid concurrency limits the damage from a segmentation fault or other error that kills a process. A single process dying will kill that process's threads but not threads in other processes.
+Hybrid concurrency limits the damage from a segmentation fault or other error that kills a process. A single process dying will kill that process's threads but not threads in other processes. Each process has its own independent garbage collector.
 
 Choosing Default Settings
 -------------------------
 
-Rails' default settings are chosen for small applications. You can improve performance for your large application that serves a lot of requests by changing them.
+Rails' default settings are chosen for small applications. You can improve performance for your large application that serves a lot of requests by changing settings.
 
 This section contains common sense defaults based on the type and size of your application and the hosts on which it runs. You can improve performance more by testing your application specifically. See "Performance Testing" for details.
 
-If you're using a Ruby implementation without a GVL such as JRuby or TruffleRuby the number of threads and processes will be completely different. These recommendations are only accurate for CRuby. These are also production recommendations. Your development application will have different needs from a production application, and should use a different configuration.
+These are production recommendations. Your development application will have different needs from a production application, and should use a different configuration.
+
+[Puma's deployment documentation](https://github.com/puma/puma/blob/master/docs/deployment.md) may also be useful.
 
 ### Threads Per Process
 
-Rails uses 3 threads per process by default. A well-optimized I/O-heavy Rails application should specify 5 or 6 threads per process at maximum. Discourse, for example, benefits from about 5 threads per process. Small applications with less I/O benefit from around 3 threads per process.
+Rails uses 3 threads per process by default. A well-optimized I/O-heavy Rails application should specify 5 or 6 threads per process at maximum. Discourse, for example, benefits from about 5 threads per process. Discourse also executes many database queries per request and frequently uses Redis. More self-contained applications with fewer database and API queries benefit from around 3 threads per process.
 
 From the default Puma configuration:
 
-    As a rule of thumb, increasing the number of threads will increase how much
-    traffic a given process can handle (throughput), but due to CRuby's
-    Global VM Lock (GVL) it has diminishing returns and will degrade the
-    response time (latency) of the application.
+> As a rule of thumb, increasing the number of threads will increase how much
+> traffic a given process can handle (throughput), but due to CRuby's
+> Global VM Lock (GVL) it has diminishing returns and will degrade the
+> response time (latency) of the application.
+
+To set the number of threads, you can change the call to the +threads+ method in +config/puma.rb+. Or you can set the +RAILS_MAX_THREADS+ environment variable, which will do the same.
 
 ### Number of Processes
 
-[Puma's deployment documentation](https://github.com/puma/puma/blob/master/docs/deployment.md) recommends running at least 1.5 processes per available processor core. Automatic methods to determine the number of cores are unreliable. You should specify the number of processes manually.
+When using hybrid threads and processes, you should run 1 process per available processor core. Automatic methods to determine the number of cores are unreliable. You should specify the number of processes manually.
+
+To set the number of worker processes, you can change the call to the +workers+ method in +config/puma.rb+. Or you can set the +WEB_CONCURRENCY+ environment variable, which will do the same.
 
 ### Preloading
 
+Puma creates new workers from a master process. By loading your application code in the master process, you can avoid doing so after creating the worker. This permits sharing more memory across processes.
 
+In a few cases it may not make sense to preload your application. In that case it's possible to turn off application preloading.
+
+Puma preloads your application by default by calling +preload_app!+ in +config/puma.rb+. If you remove this call, your application will not be preloaded.
+
+### Memory Allocators and Configuration
+
+CRuby normally uses your system's default memory allocator. You can switch to another allocator such as [jemalloc](https://github.com/jemalloc/jemalloc) or [tcmalloc](https://github.com/google/tcmalloc). You can also configure your allocator &mdash; e.g. Linux's glibc malloc allows setting MALLOC_ARENA_MAX=1 to significantly reduce memory use.
+
+This guide does not cover nonstandard allocators in significant detail. However, they can be a significant optimization relative to the system's default allocator. Long-running thread-based workers can be prone to memory fragmentation, which will reduce performance after many requests. An allocator like jemalloc can help.
 
 Performance Testing
 -------------------
 
-Settings from "Choosing Default Settings" are much better than using the initial Rails defaults. But your specific application may have unusual needs or benefit from different configuration options.
+Settings from "Choosing Default Settings" are much better than using the initial Rails defaults. Your specific application may have unusual needs or benefit from different configuration options. Load testing takes effort, but can give you more benefit than default settings. You should implement reasonable defaults first.
 
-The best way to choose your application's settings is to test the performance of your application with a simulated production workload.
+The best way to choose your application's settings is to test the performance of your application with a simulated production workload. You should save your application's load testing code so you can re-run the tests with future versions of your application.
+
+Performance testing is a deep subject. This guide gives only simple guidelines.
+
+### Load Testers
+
+You will need a load testing program to make requests of your application. This can be a dedicated load testing program of some kind, or you can write a small application to make HTTP requests and track how long they take. You should not normally check the time in your Rails logfile. That time is only how long Rails took to process the request. It does not include time taken by the application server.
+
+Sending many simultaneous requests and timing them can be difficult. It is easy to introduce subtle measurement errors. Normally you should use a load testing program, not write your own. Many load testers are simple to use and many excellent load testers are free.
+
+### What to Measure
+
+Throughput is the number of requests per second that your application successfully processes. Any good load testing program will measure it. Throughput is normally a single number for each load test.
+
+Latency is the delay from the time the request is sent until its response is successfully received. Each individual request will have its own latency.
+
+[Percentile](https://en.wikipedia.org/wiki/Percentile_rank) latency gives the latency where a certain percentage of requests have better latency than that. For instance, P90 is the 90th-percentile latency. The P90 is the latency for a single load test where only 10% of requests look longer than that to process. The P50 is the latency such that half your requests were slower, also called the median latency.
+
+"Tail latency" refers to high-percentile latencies. For instance, the P99 is the latency such that only 1% of your requests was worse. P99 is a tail latency. P50 is not a tail latency.
+
+### What You Can Change
+
+You can change the number of threads in your test to find the best tradeoff between throughput and latency for your application.
+
+You can change the number of processes to trade off performance and expense in many cases. Larger instances will need more processes for best usage. You can vary the size and type of instances from a hosting provider, for instance.
+
+You can also change other Puma configuration options such as wait_for_less_busy_worker, though you don't normally need to change them.
+
+You can test changes to memory configuration, such as using a different allocator. These are often simple better/worse tests to validate that a particular configuration works better in your production environment.
+
+Increasing the number of iterations will usually give a more exact answer, but require longer for testing.
+
+You should test on the same type of host that will run in production. Testing data for a development laptop will only tell you what settings are best for that development laptop.
+
+### Warmup
+
+Your application should process a number of requests after startup that are not included in your final measurements. These applications are called "warmup" requests, and are usually much slower than later "steady-state" requests.
+
+Your load testing program will usually support warmup requests. You can also run it more than once and throw away the first set of times.
+
+You have enough warmup requests when increasing the number does not significantly change your result. [The theory behind this can be complicated](https://arxiv.org/abs/1602.00602) but most common situations are straightforward: test several times with different amounts of warmup. See how many warmup iterations are needed before the results stay roughly the same.
+
+Very long warmup can be useful for testing memory fragmentation and other issues that happen only after many requests.
+
+### Which Requests
+
+Your application probably accepts many different HTTP requests. You should begin by load testing with just a few of them. You can add more kinds of requests over time. If a particular kind of request is too slow in your production application, you can add it to your load testing code.
+
+A synthetic workload cannot perfectly match your application's production traffic. It is still helpful for testing configurations.
+
+### What to Look For
+
+Your load testing program should allow you to check latencies, including percentile and tail latencies.
+
+For different numbers of processes and threads, or different configurations in general, check the throughput and one or more latencies such as P50, P90 and P99. For very few threads, performance will usually be bad for all of these. Increasing the threads will improve latency up to a point, and then improve throughput but worsen latency after that.
+
+Choose a tradeoff between latency and throughput based on your application's needs.


### PR DESCRIPTION
This pull request adds a new Rails Guide, tentatively called "Tuning Performance for Deployment".

A few weeks ago there was [an issue to reconsider the default thread count for Puma in Rails](https://github.com/rails/rails/issues/50450) and [a PR to make the change](https://github.com/rails/rails/pull/50669).

There was some back-and-forth suggesting it would be good to mention some of the information in a performance tuning guide, but no such guide exists. I wrote a quick one and incorporated a lot of feedback from @byroot (Jean Boussier).

If you read this and have opinions about deployment configuration for Puma in a Rails app, I'd love your review!

It's impossible, and undesirable, to have a full-detail guide to all possible Rails deployment options. This guide tries hard to focus on Puma (the default server) and CRuby, and on giving a good start to people who don't already know deployment well. Starting points, not ending points.